### PR TITLE
Include instructions for low power devices for installation.

### DIFF
--- a/setup/installation/README.md
+++ b/setup/installation/README.md
@@ -1,6 +1,7 @@
 # Installation
 
 In order to install Crowsnest, it is required that `git` is already installed. Once this is done, please execute the commands below and follow the instructions carefully.
+If you are installing Crowsnest on a device with a low amount of ram (<1GB), consider increasing swap space to hit a minimum of 1GB of memory before running the commands.
 
 ```bash
 cd ~


### PR DESCRIPTION
I have been running Crowsnest for quite some time (multiple months) on a rpi zero 2w, so the RPI zero 2W certainly supports Crowsnest.
However, the installation fails due to a lack of memory with the default MainsailOS defined swapspace (256mb).
This can be solved by simply increasing the swap space to 512mb, making for a total 1Gb of memory.

I am not convinced I have written down the changes in the best way possible, but I do believe it's worth including this information in the install instructions.